### PR TITLE
Update document for generating URLs

### DIFF
--- a/html.md
+++ b/html.md
@@ -302,22 +302,22 @@ echo Form::myField();
 
 Generate a HTML link to the given URL.
 
-    echo link_to('foo/bar', $title, $attributes = [], $secure = null);
+    echo link_to('foo/bar', $title = null, $attributes = array(), $secure = null);
 
 #### link_to_asset
 
 Generate a HTML link to the given asset.
 
-    echo link_to_asset('foo/bar.zip', $title, $attributes = [], $secure = null);
+    echo link_to_asset('foo/bar.zip', $title = null, $attributes = array(), $secure = null);
 
 #### link_to_route
 
-Generate a HTML link to the given route.
+Generate a HTML link to the given named route.
 
-    echo link_to_route('route.name', $title, $parameters = [], $attributes = []);
+    echo link_to_route('route.name', $title = null, $parameters = array(), $attributes = array());
 
 #### link_to_action
 
 Generate a HTML link to the given controller action.
 
-    echo link_to_action('HomeController@getIndex', $title, $parameters = [], $attributes = []);
+    echo link_to_action('HomeController@getIndex', $title = null, $parameters = array(), $attributes = array());

--- a/html.md
+++ b/html.md
@@ -302,22 +302,30 @@ echo Form::myField();
 
 Generate a HTML link to the given URL.
 
-    echo link_to('foo/bar', $title = null, $attributes = array(), $secure = null);
+```php
+echo link_to('foo/bar', $title = null, $attributes = array(), $secure = null);
+```
 
 #### link_to_asset
 
 Generate a HTML link to the given asset.
 
-    echo link_to_asset('foo/bar.zip', $title = null, $attributes = array(), $secure = null);
+```php
+echo link_to_asset('foo/bar.zip', $title = null, $attributes = array(), $secure = null);
+```
 
 #### link_to_route
 
 Generate a HTML link to the given named route.
 
-    echo link_to_route('route.name', $title = null, $parameters = array(), $attributes = array());
+```php
+echo link_to_route('route.name', $title = null, $parameters = array(), $attributes = array());
+```
 
 #### link_to_action
 
 Generate a HTML link to the given controller action.
 
-    echo link_to_action('HomeController@getIndex', $title = null, $parameters = array(), $attributes = array());
+```php
+echo link_to_action('HomeController@getIndex', $title = null, $parameters = array(), $attributes = array());
+```

--- a/html.md
+++ b/html.md
@@ -298,4 +298,26 @@ echo Form::myField();
 <a name="generating-urls"></a>
 ##Generating URLs
 
-For more information on generating URL's, check out the documentation on [helpers](http://laravel.com/docs/helpers#urls).
+#### link_to
+
+Generate a HTML link to the given URL.
+
+    echo link_to('foo/bar', $title, $attributes = [], $secure = null);
+
+#### link_to_asset
+
+Generate a HTML link to the given asset.
+
+    echo link_to_asset('foo/bar.zip', $title, $attributes = [], $secure = null);
+
+#### link_to_route
+
+Generate a HTML link to the given route.
+
+    echo link_to_route('route.name', $title, $parameters = [], $attributes = []);
+
+#### link_to_action
+
+Generate a HTML link to the given controller action.
+
+    echo link_to_action('HomeController@getIndex', $title, $parameters = [], $attributes = []);


### PR DESCRIPTION
As the section for these helper methods was [removed from the official documentation](https://github.com/laravel/docs/commit/f04a7766094ee4304df7a3dc61be00c119e0d541#diff-dc76c6d1ac20ba23be57617bde6f314c), I've added the documentation here rather than linking to the Laravel website.
