### PR TITLE
Update installation instructions to use "composer require"

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -13,15 +13,9 @@
 
 > If you have changed the top-level namespace to something like 'MyCompany', then you would use the new namespace instead of 'App'.
 
-Begin by installing this package through Composer. Edit your project's `composer.json` file to require `laravelcollective/annotations`.
+Begin by installing this package through Composer. Run the following from the Terminal:
 
-    "require": {
-        "laravelcollective/annotations": "5.2.*"
-    }
-
-Next, update Composer from the Terminal:
-
-    composer update
+    composer require "laravelcollective/annotations":"^5.2.0"
 
 Once composer is done, you'll need to create a Service Provider in `app/Providers/AnnotationsServiceProvider.php`.
 

--- a/bus.md
+++ b/bus.md
@@ -12,17 +12,11 @@
 
 <a name="installation"></a>
 ## Installation
-Begin by installing this package through Composer. Edit your project's `composer.json` file to require `laravelcollective/bus`.
+Begin by installing this package through Composer. Run the following from the Terminal:
 
-    "require": {
-        "laravelcollective/bus": "5.2.\*"
-    }
+    composer require "laravelcollective/bus":"^5.2.0"
 
-Next, update Composer from the Terminal:
-
-    composer update
-
-Remove `Illuminate\Bus\BusServiceProvider` from your app.php configuration file.
+Remove `Illuminate\Bus\BusServiceProvider` from your app.php configuration file if its present.
 
 Next, add your new provider to the `providers` array of `config/app.php`:
 

--- a/html.md
+++ b/html.md
@@ -20,17 +20,9 @@
 <a name="installation"></a>
 ## Installation
 
-Begin by installing this package through Composer. Edit your project's `composer.json` file to require `laravelcollective/html`.
+Begin by installing this package through Composer. Run the following from the Terminal:
 
-```json
-"require": {
-    "laravelcollective/html": "5.2.*"
-}
-```
-
-Next, update Composer from the Terminal:
-
-    composer update
+    composer require "laravelcollective/html":"^5.2.0"
 
 Next, add your new provider to the `providers` array of `config/app.php`:
 

--- a/ssh.md
+++ b/ssh.md
@@ -13,15 +13,9 @@
 
 > If you have changed the top-level namespace to something like 'MyCompany', then you would use the new namespace instead of 'App'.
 
-Begin by installing this package through Composer. Edit your project's `composer.json` file to require `laravelcollective/remote`.
+Begin by installing this package through Composer. Run the following from the Terminal:
 
-    "require": {
-        "laravelcollective/remote": "5.2.*"
-    }
-
-Next, update Composer from the Terminal:
-
-    composer update
+    composer require "laravelcollective/remote":"^5.2.0"
 
 Next, add your new provider to the `providers` array of `config/app.php`:
 


### PR DESCRIPTION
Editing the composer.json is always prone to errors, and running "composer update" updates all dependencies which in most cases is probably not wanted. In some cases where packages don't follow semantic versioning (_cough_ laravel _cough_) could see you upgrade an entire version! (e.g: 5.1 to 5.2 if the users version constraint is ~5.1)

Using "composer require" means that we only install the package requested without updating any other dependencies and also removes the need to edit the composer.json directly as its all handled for us, which means the possibility of syntax errors is removed :)

I also updated the version constraint to use ^5.2.0. I'm not sure if this actually has a performance improvement vs. 5.2.\* but using the caret is the recommended operator to use.
