### PR TITLE
Update comments to reflect related properties

### DIFF
--- a/html.md
+++ b/html.md
@@ -155,7 +155,7 @@ use Illuminate\Database\Eloquent\Model;
 class User extends Model
 {
     /**
-     * Get the user's first name.
+     * Get the user's date of birth.
      *
      * @param  string  $value
      * @return string
@@ -166,7 +166,7 @@ class User extends Model
     }
 
     /**
-     * Get the user's first name for forms.
+     * Get the user's date of birth for forms.
      *
      * @param  string  $value
      * @return string


### PR DESCRIPTION
The comments for the Form Model Accessors section had referred to a first name, but the methods related to a user's date of birth.
