### PR TITLE
Fix link for 'queues' documentation.

### DIFF
--- a/bus.md
+++ b/bus.md
@@ -145,7 +145,7 @@ If you would like to convert an existing command into a queued command, simply i
 
 Then, just write your command normally. When you dispatch it to the bus that bus will automatically queue the command for background processing. It doesn't get any easier than that.
 
-For more information on interacting with queued commands, view the full [queue documentation](/docs/{{version}}/queues).
+For more information on interacting with queued commands, view the full [queue documentation](http://laravel.com/docs/{{version}}/queues).
 
 <a name="command-pipeline"></a>
 ## Command Pipeline


### PR DESCRIPTION
My apologies if I've got this pull request back to front - I'm not always terribly good at using the GitHub tools.

Replaced the "laravelcollective.com" with a hard-coded "http://laravel.com" so that the documentation points to upstream's queue documentation.

NOTE: it might be better to have another tag which means "upstream wherever that is" but I note lower in the file someone else has done fairly much the same thing.
