### PR TITLE
Update installation instructions for 5.3 branch

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -13,15 +13,9 @@
 
 > If you have changed the top-level namespace to something like 'MyCompany', then you would use the new namespace instead of 'App'.
 
-Begin by installing this package through Composer. Edit your project's `composer.json` file to require `laravelcollective/annotations`.
+Begin by installing this package through Composer. Run the following from the terminal:
 
-    "require": {
-        "laravelcollective/annotations": "5.3.\*"
-    }
-
-Next, update Composer from the Terminal:
-
-    composer update
+    composer require "laravelcollective/annotations":"^5.3.0"
 
 Once composer is done, you'll need to create a Service Provider in `app/Providers/AnnotationsServiceProvider.php`.
 

--- a/bus.md
+++ b/bus.md
@@ -12,15 +12,9 @@
 
 <a name="installation"></a>
 ## Installation
-Begin by installing this package through Composer. Edit your project's `composer.json` file to require `laravelcollective/bus`.
+Begin by installing this package through Composer. Run the following from the terminal:
 
-    "require": {
-        "laravelcollective/bus": "5.3.\*"
-    }
-
-Next, update Composer from the Terminal:
-
-    composer update
+    composer require "laravelcollective/bus":"^5.3.0"
 
 Remove `Illuminate\Bus\BusServiceProvider` from your app.php configuration file.
 

--- a/html.md
+++ b/html.md
@@ -20,17 +20,9 @@
 <a name="installation"></a>
 ## Installation
 
-Begin by installing this package through Composer. Edit your project's `composer.json` file to require `laravelcollective/html`.
+Begin by installing this package through Composer. Run the following from the terminal:
 
-```json
-"require": {
-    "laravelcollective/html": "5.3.*"
-}
-```
-
-Next, update Composer from the Terminal:
-
-    composer update
+    composer require "laravelcollective/html":"^5.3.0"
 
 Next, add your new provider to the `providers` array of `config/app.php`:
 
@@ -296,7 +288,7 @@ echo Form::select('size', ['L' => 'Large', 'S' => 'Small'], null, ['placeholder'
 ```php
 echo Form::select('size', ['L' => 'Large', 'S' => 'Small'], null, ['multiple' => true]);
 ```
- 
+
 #### Generating A Grouped List
 
 ```php

--- a/ssh.md
+++ b/ssh.md
@@ -13,15 +13,9 @@
 
 > If you have changed the top-level namespace to something like 'MyCompany', then you would use the new namespace instead of 'App'.
 
-Begin by installing this package through Composer. Edit your project's `composer.json` file to require `laravelcollective/remote`.
+Begin by installing this package through Composer. Run the following from the terminal:
 
-    "require": {
-        "laravelcollective/remote": "5.3.*"
-    }
-
-Next, update Composer from the Terminal:
-
-    composer update
+    composer require "laravelcollective/remote":"^5.3.0"
 
 Next, add your new provider to the `providers` array of `config/app.php`:
 


### PR DESCRIPTION
As requested in #21. 

I've updated the installation instructions to use `composer require` rather than editing the `composer.json` file directly.
