### PR TITLE
Missing FormAccessible Trait

### DIFF
--- a/html.md
+++ b/html.md
@@ -140,7 +140,7 @@ This allows you to quickly build forms that not only bind to model values, but e
 
 Laravel's [Eloquent Accessor](http://laravel.com/docs/5.2/eloquent-mutators#accessors-and-mutators) allow you to manipulate a model attribute before returning it. This can be extremely useful for defining global date formats, for example. However, the date format used for display might not match the date format used for form elements. You can solve this by creating two separate accessors: a standard accessor, *and/or* a form accessor.
 
-To define a form accessor, create a `formFooAttribute` method on your model where `Foo` is the "camel" cased name of the column you wish to access. In this example, we'll define an accessor for the `date_of_birth` attribute. The accessor will automatically be called by the HTML Form Builder when attempting to pre-fill a form field when `Form::model()` is used.
+To define a form accessor, include `FormAccessible` trait and create a `formFooAttribute` method on your model where `Foo` is the "camel" cased name of the column you wish to access. In this example, we'll define an accessor for the `date_of_birth` attribute. The accessor will automatically be called by the HTML Form Builder when attempting to pre-fill a form field when `Form::model()` is used.
 
 ```php
 <?php
@@ -149,9 +149,12 @@ namespace App;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
+use Collective\Html\Eloquent\FormAccessible;
 
 class User extends Model
 {
+    use FormAccessible;
+
     /**
      * Get the user's first name.
      *


### PR DESCRIPTION
In 5.4, you still have to include the FormAccessible trait in order for the model to check for the form specific accessor.