### PR TITLE
Correct remote version number in installation section

### DIFF
--- a/ssh.md
+++ b/ssh.md
@@ -16,7 +16,7 @@
 Begin by installing this package through Composer. Edit your project's `composer.json` file to require `laravelcollective/remote`.
 
     "require": {
-        "laravelcollective/remote": "5.3.\*"
+        "laravelcollective/remote": "5.4.*"
     }
 
 Next, update Composer from the Terminal:


### PR DESCRIPTION
The 5.4 docs currently suggest using the 5.3 version of the Remote package. This closes laravelcollective/remote#52.