### PR TITLE
Mention that Form Model Accessors need the FormAccessible trait to work

### DIFF
--- a/html.md
+++ b/html.md
@@ -141,6 +141,8 @@ Laravel's [Eloquent Accessor](http://laravel.com/docs/5.2/eloquent-mutators#acce
 
 To define a form accessor, create a `formFooAttribute` method on your model where `Foo` is the "camel" cased name of the column you wish to access. In this example, we'll define an accessor for the `date_of_birth` attribute. The accessor will automatically be called by the HTML Form Builder when attempting to pre-fill a form field when `Form::model()` is used.
 
+You must include the FormAccessible trait in your model definition for this to work.
+
 ```php
 <?php
 
@@ -148,9 +150,12 @@ namespace App;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
+use Collective\Html\Eloquent\FormAccessible;
 
 class User extends Model
 {
+    use FormAccessible;     
+    
     /**
      * Get the user's first name.
      *


### PR DESCRIPTION
  A quick edit of the docs to mention that in order for Form model Acesssors  the FormAccessible must be added to the model definition.  Solves:  https://github.com/LaravelCollective/html/issues/428 
Thanks for keeping this very useful package maintained!
